### PR TITLE
Allow repeat of commands(except certain) and add adjustable expiring period of blocking the same message

### DIFF
--- a/modules/repeatblock.lua
+++ b/modules/repeatblock.lua
@@ -1,3 +1,5 @@
+local modname = minetest.get_current_modname()
+local timeout = minetest.settings:get(modname .. ".repeat_timeout") or 60
 local cache = {}
 
 local function on_chat_message(name, message)
@@ -9,6 +11,9 @@ local function on_chat_message(name, message)
         return true
     else
         cache[name] = message
+        minetest.after(timeout, function()
+                cache[name] = nil
+        end)
         return false
     end
 end

--- a/modules/repeatblock.lua
+++ b/modules/repeatblock.lua
@@ -2,8 +2,20 @@ local modname = minetest.get_current_modname()
 local timeout = minetest.settings:get(modname .. ".repeat_timeout") or 60
 local cache = {}
 
+local blocked_cmds = {
+    ["/me"] = true,
+    ["/msg"] = true,
+    ["/pm"] = true,
+    ["/m"] = true
+    }
 local function on_chat_message(name, message)
     if (cache[name] and cache[name]==message) then
+        if message:sub(1,1) == "/" then
+            local cmd = message:match("/%S+")
+            if not blocked_cmds[cmd] then
+                return false
+            end
+        end
         minetest.chat_send_player(
             name,
             minetest.colorize("red", "sorry, repeat messages are not allowed")

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,1 +1,2 @@
 shadowmute.report.discord_url (discord webhook url) string
+shadowmute.repeat_timeout (Timeout between repeating messages) int 60


### PR DESCRIPTION
Currently, repeating-messages blocker blocking every message from players, including all chatcommands. This can be uncomfortable for some players who do not chat, only periodically running the same commands, for example, `/spawn`, `/home` `/who`.
Also, the adjustable expiring period of blocking the same message can be usefull option for some cases